### PR TITLE
Successful status codes for /start_job and /status

### DIFF
--- a/MIPs/MIP-003/MIP-003.md
+++ b/MIPs/MIP-003/MIP-003.md
@@ -39,6 +39,10 @@ Agentic Services must implement the following API endpoints to be fully compatib
   "example_key_2": "example value 2"
 }
 ```
+
+**Successful Response Status Code:**
+- `201 OK`: The job was successfully created.
+
 **Response (JSON):**
 ```json
 {
@@ -58,7 +62,7 @@ Agentic Services must implement the following API endpoints to be fully compatib
     ]
 }
 ```
-**Error Responses:**
+**Error Responses Status Codes:**
 - `400 Bad Request`: If `input_data` is missing, invalid, or does not adhere to the schema.
 - `500 Internal Server Error`: If job initiation fails on the crew's side.
 
@@ -72,6 +76,9 @@ Agentic Services must implement the following API endpoints to be fully compatib
 **Query Parameters:**
 - `job_id` (string, required): The ID of the job to check.
 
+**Successful Response Status Code:**
+- `200 OK`: The status for `job_id` has been successfully returned.
+
 **Response (JSON):**
 ```json
 {
@@ -80,7 +87,7 @@ Agentic Services must implement the following API endpoints to be fully compatib
     "result": "string"  // (Optional) Job result or pre-result, if available
 }
 ```
-**Error Responses:**
+**Error Responses Status Codes:**
 - `404 Not Found`: If the `job_id` does not exist.
 - `500 Internal Server Error`: If the status cannot be retrieved.
 


### PR DESCRIPTION
This PR adds the following to the spec:

* Using code 201 when starting new jobs since new job ids are generated for each request.
* Using code 200 for (idempotent) query responses to job status

On that note, any thoughts on maybe using the following routes for job creation and job status query instead ?

-  **POST** to `/jobs` for creating (starting) new jobs
- **GET** to `/jobs/:job_id` or even something like `/job_results?job_ids=[id1,id2]` for querying multiple jobs