### PR TITLE
docs(MIP-003): replace status id with input_schema_hash in provide_input

### DIFF
--- a/MIPs/MIP-003/MIP-003.md
+++ b/MIPs/MIP-003/MIP-003.md
@@ -39,7 +39,7 @@ Agentic Services must implement the following API endpoints to be fully compatib
 |----------|--------|----------|---------|--------------|----------|
 | [`/start_job`](#start-job) | `POST` | ✓ | Initiates a job on the remote crew | `identifier_from_purchaser`,  `input_data` | Job details with payment info |
 | [`/status`](#check-job-status) | `GET` | ✓ | Retrieves the status of a specific job | Query param: `job_id` | Job status and optional input requirements |
-| [`/provide_input`](#provide-input) | `POST` | ✗ | Provides additional input for a job awaiting input | `job_id`, `status_id`, `input_data` | Success confirmation |
+| [`/provide_input`](#provide-input) | `POST` | ✗ | Provides additional input for a job awaiting input | `job_id`, `input_schema_hash`, `input_data` | Success confirmation |
 | [`/availability`](#check-server-availability) | `GET` | ✓ | Checks if the server is operational | None | Server availability status |
 | [`/input_schema`](#retrieve-input-schema) | `GET` | ✓ | Returns the expected input format for jobs | None | Input schema definition |
 | [`/demo`](#get-demo-data) | `GET` | ✗ | Returns demo data for marketing purposes | None | Sample input and output demo information |
@@ -139,7 +139,6 @@ GET https://example-url.com/status?job_id=18d66eed-6af5-4589-b53a-d2e78af657b6
 
 | Field | Required | Type | Description | Example |
 |-------|----------|------|-------------|---------|
-| `id` | Yes | string | Unique Identifier of the status | `8731ecb3-3bcc-4ebc-b46ff7dd12dd` |
 | `status` | Yes | string | Current status of the job | `"awaiting_payment"`, `"awaiting_input"`, `"running"`, `"completed"`, `"failed"` |
 | `input_schema` | No | object | Only required when status is "awaiting_input". See [Attachment 01](./MIP-003-Attachement-01.md) for details | <details><summary>View Structure</summary><pre>{<br> "input_data": [{<br>  "id": "linkedin_url",<br>  "type": "string",<br>  "name": "LinkedIn Profile URL",<br>  "data": {...},<br>  "validations": [...]<br>  }]<br>}</pre></details> |
 | `result` | No | string | Job result or pre-result, if available | `"Resume generated successfully"` |
@@ -149,7 +148,6 @@ GET https://example-url.com/status?job_id=18d66eed-6af5-4589-b53a-d2e78af657b6
 
 ```json
 {
-  "id": "8731ecb3-3bcc-4ebc-b46ff7dd12dd",
   "status": "running"
 }
 ```
@@ -160,7 +158,6 @@ GET https://example-url.com/status?job_id=18d66eed-6af5-4589-b53a-d2e78af657b6
 
 ```json
 {
-  "id": "8731ecb3-3bcc-4ebc-b46ff7dd12dd",
   "status": "awaiting_input",
   "input_schema": {
     "input_data": [
@@ -189,7 +186,6 @@ GET https://example-url.com/status?job_id=18d66eed-6af5-4589-b53a-d2e78af657b6
 
 ```json
 {
-  "id": "8731ecb3-3bcc-4ebc-b46ff7dd12dd",
   "status": "awaiting_input",
   "input_schema": {
     "input_groups": [
@@ -272,7 +268,7 @@ It is possible to create enforce complex data validation. To learn please take a
 | Field | Required | Type | Description | Example |
 |-------|----------|------|-------------|---------|
 | `job_id` | Yes | string | Job ID awaiting input | `"18d66eed-6af5-4589-b53a-d2e78af657b6"` |
-| `status_id` | Yes | string | Status ID awaiting input | `"8731ecb3-3bcc-4ebc-b46ff7dd12dd"` |
+| `input_schema_hash` | Yes | string | Canonical JSON SHA256 hash of the `input_schema` object (computed by the client from the `input_schema` in the `/status` response when status is "awaiting_input") | `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"` |
 | `input_data` | Yes | object | All inputs are to be defined in the /input_schema endpoint and depend on what the Agentic Service expects | <details><summary>View Simple Example</summary><pre>{<br>  "linkedin_url": "https://linkedin.com/in/alice-johnson"<br>}</pre></details> |
 
 <details>
@@ -281,13 +277,15 @@ It is possible to create enforce complex data validation. To learn please take a
 ```json
 {
   "job_id": "18d66eed-6af5-4589-b53a-d2e78af657b6",
-  "status_id": "8731ecb3-3bcc-4ebc-b46ff7dd12dd",
+  "input_schema_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "input_data": {
     "linkedin_url": "https://linkedin.com/in/alice-johnson"
   }
 }
 ```
 </details>
+
+**Note:** The `input_schema_hash` is computed as SHA256 of the canonical JSON serialization of the `input_schema` object (e.g. keys sorted lexicographically, no unnecessary whitespace) so that the same schema always produces the same hash.
 
 ##### Response Body
 

--- a/MIPs/MIP-003/MIP-003.md
+++ b/MIPs/MIP-003/MIP-003.md
@@ -268,7 +268,7 @@ It is possible to create enforce complex data validation. To learn please take a
 | Field | Required | Type | Description | Example |
 |-------|----------|------|-------------|---------|
 | `job_id` | Yes | string | Job ID awaiting input | `"18d66eed-6af5-4589-b53a-d2e78af657b6"` |
-| `input_schema_hash` | Yes | string | Canonical JSON SHA256 hash of the `input_schema` object (computed by the client from the `input_schema` in the `/status` response when status is "awaiting_input") | `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"` |
+| `input_schema_hash` | Yes | string | SHA256 hash of the canonical JSON serialization of the `input_schema` object (computed by the client from the `/status` response when status is "awaiting_input"), encoded as a lowercase hexadecimal string (64 characters) | `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"` |
 | `input_data` | Yes | object | All inputs are to be defined in the /input_schema endpoint and depend on what the Agentic Service expects | <details><summary>View Simple Example</summary><pre>{<br>  "linkedin_url": "https://linkedin.com/in/alice-johnson"<br>}</pre></details> |
 
 <details>
@@ -285,7 +285,7 @@ It is possible to create enforce complex data validation. To learn please take a
 ```
 </details>
 
-**Note:** The `input_schema_hash` is computed as SHA256 of the canonical JSON serialization of the `input_schema` object (e.g. keys sorted lexicographically, no unnecessary whitespace) so that the same schema always produces the same hash.
+**Note:** The `input_schema_hash` is the SHA256 digest of the canonical JSON serialization of the `input_schema` object (e.g. keys sorted lexicographically, no unnecessary whitespace), encoded as a lowercase hexadecimal string, so that the same schema always produces the same hash.
 
 ##### Response Body
 


### PR DESCRIPTION
## Summary

Updates MIP-003 Agentic Service API so that `/status` no longer returns an `id`, and `/provide_input` identifies the schema in use via a client-computed `input_schema_hash` (canonical JSON SHA256) instead of `status_id`.

## Key changes

- **`/status` response**: Removed the `id` field from the response body and from all examples (running, awaiting_input with input_data, awaiting_input with input_groups).
- **`/provide_input` request**: Replaced `status_id` with `input_schema_hash`. The client computes this as the SHA256 hash of the canonical JSON serialization of the `input_schema` object received in the `/status` response when status is `"awaiting_input"`.
- **Documentation**: Added a note that canonical JSON means deterministic serialization (e.g. keys sorted lexicographically, no unnecessary whitespace) so the same schema always yields the same hash.
- **Endpoints overview**: Updated the `/provide_input` row to list `input_schema_hash` instead of `status_id` in the request body column.

## Technical details

- `input_schema_hash` is not returned by `/status`; clients derive it from the existing `input_schema` payload.
- Services can verify that provided input was intended for the current schema by recomputing the hash server-side and matching it to the client-supplied `input_schema_hash`.

## Testing

- N/A (spec/documentation only). Implementations should update clients to compute and send `input_schema_hash` and servers to accept it instead of `status_id`; servers should stop returning `id` in `/status`.
